### PR TITLE
Small fix for password fields

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -418,7 +418,7 @@ if ($step == "3"){
 			<tr>
 				<td>&nbsp;Database Password</td>
 				<td>
-					<input type="text" name="database_password" size="30" value="<?php echo $database_password?>">
+					<input type="password" name="database_password" size="30" value="<?php echo $database_password?>">
 				</td>
 			</tr>
 			<tr>
@@ -466,7 +466,7 @@ if ($step == "3"){
 			<tr>
 				<td>&nbsp;Database Password</td>
 				<td>
-					<input type="text" name="database_password" size="30" value="<?php echo $database_password?>">
+					<input type="password" name="database_password" size="30" value="<?php echo $database_password?>">
 				</td>
 			</tr>
 


### PR DESCRIPTION
Greetings CORAL developers,

We just installed CORAL here at Hekman Library of Calvin College (MI).  Looks promising!  I noticed that the password input fields showed my passwords during the web installation, so I thought I'd commit a fix for that.  If you accept it in this module, I'll go ahead and fix it in the other modules too.

Remington Steed
rjs7@calvin.edu
